### PR TITLE
ENH: Use alternative regex and backport pr branch names

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
         github.event.action == 'closed'
         || (
           github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
+          && contains(github.event.label.name, 'backport:')
         )
       )
     steps:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
       The data properties are:
         - base: backport PR's base branch
         - number: original PR's number
-    default: "backport-<%= number %>-to-<%= base %>"
+    default: "backport/<%= base %>/PR-<%= number %>"
   label_pattern:
     description: >
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.
@@ -45,7 +45,7 @@ inputs:
         - base: backport PR's base branch
         - number: original PR's number
         - title: original PR's title
-    default: "[Backport <%= base %>] <%= title %>"
+    default: "[Backport of <%= base %>] to <%= title %>"
 outputs:
   created_pull_requests:
     description: A JSON stringified object mapping the base branch of the created pull requests to their number.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Backporting
-author: Thibault Derousseaux <tibdex@gmail.com>
+author: Dean Kuhne
 description: >
   Automatically backport PRs to other branches by simply labeling them.
 inputs:
@@ -28,7 +28,7 @@ inputs:
     description: >
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.
       The backport PR's base branch will be extracted from the pattern's required `base` named capturing group.
-    default: "^backport (?<base>([^ ]+))$"
+    default: "^backport: (?<base>([^ ]+))$"
   labels_template:
     description: >
       Lodash template compiling to a JSON array of labels to add to the backport PR.


### PR DESCRIPTION
- The backport action now uses "backport:" to initiate the backport action rather than "backport"

- Backport branches are now "backport/<target branch>/PR-<backported PR #>