### PR TITLE
Replace "[Backport]" with "backport:" in PR Title Template

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
         - base: backport PR's base branch
         - number: original PR's number
         - title: original PR's title
-    default: "[Backport] PR #<%= number %> to <%= base %> (<%= title %>)"
+    default: "backport: PR #<%= number %> to <%= base %> (<%= title %>)"
 outputs:
   created_pull_requests:
     description: A JSON stringified object mapping the base branch of the created pull requests to their number.


### PR DESCRIPTION
Done since we implemented a new regex pattern for commits, such that merged PRs are squashed and the commit it the PR title.

^(chore|enh|feat|fix|process|revert|test|backport){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*) is the current requirement.

This means that we should have "backport" at the start of the title, without brackets or caps usage.